### PR TITLE
Migrates argument parsing to argparse

### DIFF
--- a/gitchangelog.py
+++ b/gitchangelog.py
@@ -904,7 +904,7 @@ def changelog(repository,
 
     section_order = [k for k, _v in section_regexps]
 
-    if not args.exclude_head:
+    if args is None or not args.exclude_head:
         tags = [repository.commit("HEAD")] + tags
 
     ## Get the changes between tags (releases)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -310,7 +310,7 @@ class TestInitArgument(BaseGitReposTest):
 
     def test_init_file(self):
 
-        out, err, errlvl = cmd('$tprog init')
+        out, err, errlvl = cmd('$tprog --init')
         self.assertEqual(
             errlvl, 0,
             msg="Should not fail to init on simple git repository")
@@ -329,7 +329,7 @@ class TestInitArgument(BaseGitReposTest):
     def test_init_file_already_exists(self):
 
         w("touch .gitchangelog.rc")
-        out, err, errlvl = cmd('$tprog init')
+        out, err, errlvl = cmd('$tprog --init')
         self.assertEqual(
             errlvl, 1,
             msg="Should fail to init on simple git repository")
@@ -349,7 +349,7 @@ class TestInitArgument(BaseGitReposTest):
             git clone --bare repos test_bare
 
         """)
-        out, err, errlvl = cmd('cd ../test_bare && $tprog init')
+        out, err, errlvl = cmd('cd ../test_bare && $tprog --init')
         self.assertEqual(
             errlvl, 1,
             msg="Should fail to init outside a git repository.")
@@ -369,7 +369,7 @@ class TestInitArgument(BaseGitReposTest):
             cd subdir
 
         """)
-        out, err, errlvl = cmd('$tprog init')
+        out, err, errlvl = cmd('$tprog --init')
         self.assertEqual(
             errlvl, 0,
             msg="Should not fail in sub directory.")
@@ -441,7 +441,7 @@ class TestInitArgumentNotAReposity(BaseTmpDirTest):
 
     def test_outside_git_repository(self):
 
-        out, err, errlvl = cmd('$tprog init')
+        out, err, errlvl = cmd('$tprog --init')
         self.assertEqual(
             errlvl, 1,
             msg="Should fail to init outside a git repository.")


### PR DESCRIPTION
Migrates to argparse, which allows easy addition of options. New options are min/max tag (positional arguments), --init, and --exclude-head (excludes HEAD from the list of tags). A full list of options can be shown when invoking the command with -h/--help.