### PR TITLE
fix: pkg: Included missing markdown template

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ data_files=
         gitchangelog.rc.reference
     templates/mustache =
         templates/mustache/restructuredtext.tpl
+        templates/mustache/markdown.tpl
     templates/mako =
         templates/mako/octobercms-plugin.tpl
         templates/mako/restructuredtext.tpl


### PR DESCRIPTION
Markdown template was missing in configs