### PR TITLE
new: added option to set a custom directory where a template is located

### DIFF
--- a/gitchangelog.py
+++ b/gitchangelog.py
@@ -656,12 +656,15 @@ def first_matching(section_regexps, string):
                 return section
 
 
-def ensure_template_file_exists(label, template_name):
+def ensure_template_file_exists(label, template_name, dir):
     """Return"""
 
-    template_dir = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "templates", label)
+    if dir:
+        template_dir = dir
+    else:
+        template_dir = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "templates", label)
 
     template_path = os.path.join(template_dir, "%s.tpl" % template_name)
 
@@ -735,13 +738,13 @@ def rest_py(data, opts={}):
 if pystache:
 
     @available_in_config
-    def mustache(template_name):
+    def mustache(template_name, dir=None):
         """Return a callable that will render a changelog data structure
 
         returned callable must take 2 arguments ``data`` and ``opts``.
 
         """
-        template_path = ensure_template_file_exists("mustache", template_name)
+        template_path = ensure_template_file_exists("mustache", template_name, dir)
 
         with open(template_path) as f:
             template = f.read()
@@ -772,7 +775,7 @@ if pystache:
 else:
 
     @available_in_config
-    def mustache(template_name):
+    def mustache(template_name, dir=None):
         die("Required 'pystache' python module not found.")
 
 
@@ -784,13 +787,13 @@ if mako:
                                               paragraph_wrap))
 
     @available_in_config
-    def makotemplate(template_name):
+    def makotemplate(template_name, dir=None):
         """Return a callable that will render a changelog data structure
 
         returned callable must take 2 arguments ``data`` and ``opts``.
 
         """
-        template_path = ensure_template_file_exists("mako", template_name)
+        template_path = ensure_template_file_exists("mako", template_name, dir)
 
         template = mako.template.Template(filename=template_path)
 
@@ -805,7 +808,7 @@ if mako:
 else:
 
     @available_in_config
-    def makotemplate(template_name):
+    def makotemplate(template_name, dir=None):
         die("Required 'mako' python module not found.")
 
 

--- a/gitchangelog.rc.reference
+++ b/gitchangelog.rc.reference
@@ -193,9 +193,3 @@ output_engine = rest_py
 ## This option tells git-log whether to include merge commits in the log.
 ## The default is to include them.
 include_merge = True
-
-## ``template_dir`` is a string
-##
-## This string will tell gitchangelog where to look for templates.
-## If no value is passed, the default location will be used.
-#template_dir = '.'

--- a/gitchangelog.rc.reference
+++ b/gitchangelog.rc.reference
@@ -161,19 +161,21 @@ unreleased_version_label = "%%version%% (unreleased)"
 ##        Legacy pure python engine, outputs ReSTructured text.
 ##        This is the default.
 ##
-##   - mustache(<template_name>)
+##   - mustache(<template_name>[, <optional_dir>])
 ##
 ##        Template name could be any of the available templates in
-##        ``templates/mustache/*.tpl``.
+##        ``templates/mustache/*.tpl`` or in the custom directory passed
+##        as second argument.
 ##        Requires python package ``pystache``.
 ##        Examples:
 ##           - mustache("markdown")
 ##           - mustache("restructuredtext")
 ##
-##   - makotemplate(<template_name>)
+##   - makotemplate(<template_name>[, <optional_dir>])
 ##
 ##        Template name could be any of the available templates in
-##        ``templates/mako/*.tpl``.
+##        ``templates/mako/*.tpl`` or in the custom directory passed
+##        as second argument.
 ##        Requires python package ``mako``.
 ##        Examples:
 ##           - makotemplate("restructuredtext")
@@ -181,7 +183,9 @@ unreleased_version_label = "%%version%% (unreleased)"
 output_engine = rest_py
 #output_engine = mustache("restructuredtext")
 #output_engine = mustache("markdown")
+#output_engine = mustache("custom_template", "/path/to/custom/template/")
 #output_engine = makotemplate("restructuredtext")
+#output_engine = makotemplate("custom_template", "/path/to/custom/template/")
 
 
 ## ``include_merge`` is a boolean
@@ -189,3 +193,9 @@ output_engine = rest_py
 ## This option tells git-log whether to include merge commits in the log.
 ## The default is to include them.
 include_merge = True
+
+## ``template_dir`` is a string
+##
+## This string will tell gitchangelog where to look for templates.
+## If no value is passed, the default location will be used.
+#template_dir = '.'


### PR DESCRIPTION
Added users the chance to specify a directory along with a template name and an engine, so they can locate their templates wherever they want. Useful to keep them in the repository whose changelog is going to be generated.
