### PR TITLE
Detection of reverted commits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,8 @@ And here is the ``gitchangelog`` output::
     sample rc file. [Valentin Lab]
 
   - Added a succint ``--help`` support. [Valentin Lab]
+  
+    ! Reverted by Brian on 2016-04-23
 
   Fix
   ~~~

--- a/gitchangelog.rc.reference
+++ b/gitchangelog.rc.reference
@@ -143,6 +143,14 @@ subject_process = (strip |
 tag_filter_regexp = r'^[0-9]+\.[0-9]+(\.[0-9]+)?$'
 
 
+## ``revert_regexp`` is a regexp
+##
+## Commit bodies that mark a revert commit must match this regexp.
+## The first group must be the commit hash.
+##
+revert_regexp = r'This reverts commit ([0-9a-f]+)\.'
+
+
 ## ``unreleased_version_label`` is a string
 ##
 ## This label will be used as the changelog Title of the last set of changes


### PR DESCRIPTION
The changelog may contain commits that have been reverted.
A warning line is added on each of these commits.

Why ? Before we publish, one team member will revise and rework the changelog.
The warning aids him to not accidentially advertise a reverted feature.