### PR TITLE
fix: unescape variables in mustache templates

### DIFF
--- a/templates/mustache/markdown.tpl
+++ b/templates/mustache/markdown.tpl
@@ -4,13 +4,13 @@
 ## {{label}}
 
 {{#sections}}
-### {{label}}
+### {{{label}}}
 
 {{#commits}}
-* {{subject}} [{{author}}]
+* {{{subject}}} [{{{author}}}]
 {{#body}}
 
-{{body_indented}}
+{{{body_indented}}}
 {{/body}}
 
 {{/commits}}

--- a/templates/mustache/restructuredtext.tpl
+++ b/templates/mustache/restructuredtext.tpl
@@ -1,23 +1,23 @@
 {{#general_title}}
-{{title}}
+{{{title}}}
 {{#title_chars}}={{/title_chars}}
 
 {{/general_title}}
 {{#versions}}
-{{label}}
+{{{label}}}
 {{#label_chars}}-{{/label_chars}}
 
 {{#sections}}
 {{#display_label}}
-{{label}}
+{{{label}}}
 {{#label_chars}}~{{/label_chars}}
 
 {{/display_label}}
 {{#commits}}
-- {{subject}} [{{author}}]
+- {{{subject}}} [{{{author}}}]
 
 {{#body}}
-{{body_indented}}
+{{{body_indented}}}
 
 {{/body}}
 {{/commits}}


### PR DESCRIPTION
> All variables are HTML escaped by default. If you want to return unescaped HTML, use the triple mustache: {{{name}}}.

--- [mustache manual](https://mustache.github.io/mustache.5.html)

Thanks!