### PR TITLE
Specifying directly a file as template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,11 +222,27 @@ Mustache
 
 The ``mustache``  output engine uses `mustache templates`_.
 
-The `mustache`_ templates for ``gitchangelog`` are located in
-``templates/mustache`` and are powered via `pystache`_ the python
+The `mustache`_ templates are powered via `pystache`_ the python
 implementation of the `mustache`_ specifications. So `mustache`_ output engine
 will only be available if you have `pystache`_ module available in your python
 environment.
+
+There are `mustache templates`_ bundled with the default installation
+of gitchangelog. These can be called by providing a simple label to the
+``mustache(..)`` output_engine, for instance (in your ``.gitchangelog.rc``)::
+
+    output_engine = mustache("markdown")
+
+Or you could provide your own mustache template by specifying an absolute
+path (or a relative one, starting from the git toplevel of your project) to
+your template file, for instance::
+
+    output_engine = mustache(".gitchangelog.tpl")
+
+And feel free to copy the bundled templates to use them as bases for your
+own variations. These are located in ``src/gitchangelog/templates/mustache``
+directory in the source and are installed in ``templates/mustache`` directory
+starting from where your ``gitchangelog.py`` was installed.
 
 .. _mustache: http://mustache.github.io
 .. _pystache: https://pypi.python.org/pypi/pystache
@@ -236,10 +252,27 @@ environment.
 Mako
 ~~~~
 
-The ``makotemplate`` output engine templates for ``gitchangelog`` are located in
-``templates/mako`` and are powered via `mako`_ python templating system. So
-`mako`_ output engine will only be available if you have `mako`_ module
-available in your python environment.
+The ``makotemplate`` output engine templates for ``gitchangelog`` are
+powered via `mako`_ python templating system. So `mako`_ output engine
+will only be available if you have `mako`_ module available in your
+python environment.
+
+There are `mako`_ templates bundled with the default installation
+of gitchangelog. These can be called by providing a simple label to the
+``makotemplate(..)`` output_engine, for instance (in your ``.gitchangelog.rc``)::
+
+    output_engine = makotemplate("markdown")
+
+Or you could provide your own mako template by specifying an absolute
+path (or a relative one, starting from the git toplevel of your project) to
+your template file, for instance::
+
+    output_engine = makotemplate(".gitchangelog.tpl")
+
+And feel free to copy the bundled templates to use them as bases for your
+own variations. These are located in ``src/gitchangelog/templates/mako``
+directory in the source and are installed in ``templates/mako`` directory
+starting from where your ``gitchangelog.py`` was installed.
 
 .. _mako: http://www.makotemplates.org
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,5 @@ init:
 build: false  ## Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "python src\\gitchangelog\\gitchangelog.py"
+  - "python src\\gitchangelog\\gitchangelog.py --debug"
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -736,8 +736,8 @@ def ensure_template_file_exists(label, template_name):
         if len(templates) > 0:
             msg = ("These are the available %s templates:" % label)
             msg += "\n - " + \
-                  "\n - ".join(os.path.basename(f).split(".")[0]
-                               for f in templates)
+                   "\n - ".join(os.path.basename(f).split(".")[0]
+                                for f in templates)
             msg += "\nTemplates are located in %r" % template_dir
         else:
             msg = "No available %s templates found in %r." \

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -723,7 +723,19 @@ def first_matching(section_regexps, string):
 
 
 def ensure_template_file_exists(label, template_name):
-    """Return"""
+    """Return template file path given a label hint and the template name
+
+    Template name can be either a filename with full path,
+    if this is the case, the label is of no use.
+
+    If ``template_name`` does not refer to an existing file,
+    then ``label`` is used to find a template file in the
+    the bundled ones.
+
+    """
+
+    if os.path.isfile(template_name):
+        return template_name
 
     template_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -1199,6 +1211,11 @@ def main():
 
     if not os.path.exists(reference_config):
         die("Config reference file %r not found." % reference_config)
+
+    ## config file may lookup for templates relative to the toplevel
+    ## of git repository
+    os.chdir(repository.toplevel)
+
     config = load_config_file(
         os.path.expanduser(changelogrc),
         default_filename=reference_config,

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1157,6 +1157,8 @@ def main():
     try:
         repository = GitRepos(".")
     except EnvironmentError as e:
+        if DEBUG:
+            raise
         try:
             die(str(e))
         except Exception as e2:

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -794,8 +794,8 @@ def rest_py(data, opts={}):
     return (((rest_title(data["title"], char="=") + "\n\n")
              if data["title"] else "") +
             "\n\n".join(render_version(version)
-                      for version in data["versions"]
-                      if len(version["sections"]) > 0)) + "\n\n"
+                        for version in data["versions"]
+                        if len(version["sections"]) > 0)) + "\n\n"
 
 ## formatter engines
 
@@ -828,7 +828,7 @@ if pystache:
                 for section in version["sections"]:
                     section["label_chars"] = list(section["label"])
                     section["display_label"] = \
-                        not (section["label"] == "Other" and \
+                        not (section["label"] == "Other" and
                              len(version["sections"]) == 1)
                     for commit in section["commits"]:
                         commit["body_indented"] = indent(commit["body"])
@@ -904,9 +904,9 @@ def changelog(repository, revlist=None,
     :param revlist: list of strings that git log understands as revlist
     :param ignore_regexps: list of regexp identifying ignored commit messages
     :param section_regexps: regexps identifying sections
-    :param tag_filter_regexp: regexp to match tags used as version
     :param unreleased_version_label: version label for untagged commits
-    :param template_format: format of template to generate the changelog
+    :param tag_filter_regexp: regexp to match tags used as version
+    :param output_engine: callable to render the changelog data
     :param include_merge: whether to include merge commits in the log or not
     :param body_process: text processing object to apply to body
     :param subject_process: text processing object to apply to subject
@@ -919,7 +919,7 @@ def changelog(repository, revlist=None,
 
     opts = {
         'unreleased_version_label': unreleased_version_label,
-        }
+    }
 
     ## Setting main container of changelog elements
     title = None if revlist else "Changelog"
@@ -943,15 +943,16 @@ def changelog(repository, revlist=None,
 
     if not tags:
         warn("no tag %sname matching tag_filter_regexp %r."
-            % ("contained in revlist %r with " %  " ".join(revlist)
-               if revlist else "",
-               tag_filter_regexp))
+             % ("contained in revlist %r with " %  " ".join(revlist)
+                if revlist else "",
+                tag_filter_regexp))
 
     tags.append(repository.commit("HEAD"))
 
     if revlist:
-        max_rev = repository.commit(swrap("git rev-list -n 1 %s"
-                             % " ".join(revlist))) if revlist else None
+        max_rev = repository.commit(swrap(
+            "git rev-list -n 1 %s"
+            % " ".join(revlist))) if revlist else None
         new_tags = []
         for tag in tags:
             if max_rev < tag:
@@ -1005,7 +1006,6 @@ def changelog(repository, revlist=None,
     if not changelog["versions"]:
         warn("Empty changelog. No commits were elected to be used as entry.")
 
-
     return output_engine(data=changelog, opts=opts)
 
 ##
@@ -1013,6 +1013,7 @@ def changelog(repository, revlist=None,
 ##
 
 _obsolete_options_managers = []
+
 
 def obsolete_option_manager(fun):
     _obsolete_options_managers.append(fun)
@@ -1048,6 +1049,7 @@ def obsolete_body_split_regexp(config):
 def manage_obsolete_options(config):
     for man in _obsolete_options_managers:
         man(config)
+
 
 ##
 ## Command line parsing
@@ -1110,7 +1112,6 @@ def parse_cmd_line(usage, description, epilog, exname, version):
 ##
 ## Main
 ##
-
 
 def main():
 
@@ -1181,7 +1182,7 @@ def main():
         (True, lambda: os.environ.get('GITCHANGELOG_CONFIG_FILENAME')),
         (True, lambda: gc_rc),
         (False, lambda: ('%s/.%s.rc' % (repository.toplevel, basename)) \
-                 if not repository.bare else None),
+                        if not repository.bare else None),
         ## Removed to enforce per-repository gitchangelog file.
         # (False, lambda: os.path.expanduser('~/.%s.rc' % basename)),
         # (False, lambda: '/etc/%s.rc' % basename),
@@ -1258,14 +1259,10 @@ def main():
     else:
         print(content.encode(_preferred_encoding))
 
+
 ##
 ## Launch program
 ##
 
 if __name__ == "__main__":
-
-    # import doctest
-    # doctest.testmod()
-    # sys.exit(1)
-
     main()

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -616,6 +616,40 @@ EOF
                     msg="Should not fail on %s(%r) " % (label, tpl) +
                     "Current stderr:\n%s" % indent(err))
 
+    def test_file_template_name(self):
+        """Existing files should be accepted as valid templates"""
+
+        w("""
+             cat <<EOF > mytemplate.tpl
+check: {{{title}}}
+EOF
+             cat <<EOF > .gitchangelog.rc
+
+output_engine = mustache('mytemplate.tpl')
+
+EOF
+        """)
+
+        reference = """check: Changelog
+
+"""
+
+        out, err, errlvl = cmd('$tprog')
+        self.assertEqual(
+            err, "",
+            msg="There should be non error messages. "
+            "Current stderr:\n%s" % err)
+        self.assertEqual(
+            errlvl, 0,
+            msg="Should succeed to find template")
+        self.assertEqual(
+            out, reference,
+            msg="Mako output should match our reference output... "
+            "diff of changelogs:\n%s"
+            % '\n'.join(difflib.unified_diff(reference.split("\n"),
+                                             out.split("\n"),
+                                             lineterm="")))
+
 
 class TestInitArgument(BaseGitReposTest):
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -616,6 +616,40 @@ EOF
                     msg="Should not fail on %s(%r) " % (label, tpl) +
                     "Current stderr:\n%s" % indent(err))
 
+    def test_unexistent_template_name(self):
+        """Unexisting template should get a proper error message"""
+
+        w("""cat <<EOF > .gitchangelog.rc
+
+output_engine = mustache('doesnotexist')
+
+EOF
+        """)
+        out, err, errlvl = cmd('$tprog')
+        self.assertEqual(
+            errlvl, 1,
+            msg="Should fail as template does not exist")
+        self.assertEqual(
+            out, "",
+            msg="No stdout was expected since there was an error. "
+            "Current stdout:\n%r" % out)
+        self.assertContains(
+            err, "doesnotexist",
+            msg="There should be an error message mentioning 'doesnotexist'. "
+            "Current stderr:\n%s" % err)
+        self.assertContains(
+            err, "restructuredtext",
+            msg="The error message should mention 'available'. "
+            "Current stderr:\n%s" % err)
+        self.assertContains(
+            err, "mustache",
+            msg="The error message should mention 'mustache'. "
+            "Current stderr:\n%s" % err)
+        self.assertContains(
+            err, "restructuredtext",
+            msg="The error message should mention 'restructuredtext'. "
+            "Current stderr:\n%s" % err)
+
     def test_file_template_name(self):
         """Existing files should be accepted as valid templates"""
 
@@ -747,39 +781,6 @@ class TestInitArgument(BaseGitReposTest):
             msg="There should be no standard output. "
             "Current stdout:\n%s" % out)
 
-    def test_unexistent_template_name(self):
-        """Reference implementation should match mustache and mako implem"""
-
-        w("""cat <<EOF > .gitchangelog.rc
-
-output_engine = mustache('doesnotexist')
-
-EOF
-        """)
-        out, err, errlvl = cmd('$tprog')
-        self.assertEqual(
-            errlvl, 1,
-            msg="Should fail as template does not exist")
-        self.assertEqual(
-            out, "",
-            msg="No stdout was expected since there was an error. "
-            "Current stdout:\n%r" % out)
-        self.assertContains(
-            err, "doesnotexist",
-            msg="There should be an error message mentioning 'doesnotexist'. "
-            "Current stderr:\n%s" % err)
-        self.assertContains(
-            err, "restructuredtext",
-            msg="The error message should mention 'available'. "
-            "Current stderr:\n%s" % err)
-        self.assertContains(
-            err, "mustache",
-            msg="The error message should mention 'mustache'. "
-            "Current stderr:\n%s" % err)
-        self.assertContains(
-            err, "restructuredtext",
-            msg="The error message should mention 'restructuredtext'. "
-            "Current stderr:\n%s" % err)
 
 
 class TestInitArgumentNotAReposity(BaseTmpDirTest):


### PR DESCRIPTION
When implementing this I wanted to keep full compatibility with previous behavior.
You can now provide a template directly in your git repository (or elsewhere) and refer to it by specifying its relative (starting from the git toplevel) or absolute path.

For instance, in your ``.gitchangelog.rc``:

    mustache(".gitchangelog.tpl")

Would then look for ".gitchangelog.tpl" in your git toplevel directory. Of course this works also for mako templates.

The code was based on #46 ideas, so thank you to @hctpbl, you are credited as ``Co-Authored-By`` (which should be hopefully be used by ``gitchangelog`` soon #69).

This will fix also issue #63 .