### PR TITLE
Add tag's subject to data structure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -331,7 +331,8 @@ This is a sample of the current data structure sent to output engines::
   {'title': 'Changelog',
    'versions': [{'label': '%%version%% (unreleased)',
                  'date': None,
-                 'tag': None
+                 'tag': None,
+                 'subject': None,
                  'sections': [{'label': 'Changes',
                                'commits': [{'author': 'John doe',
                                             'body': '',
@@ -348,7 +349,8 @@ This is a sample of the current data structure sent to output engines::
                                             'subject': 'Adding some stuff to do.'}]}]},
                 {'label': 'v0.2.5 (2013-08-06)',
                  'date': '2013-08-06',
-                 'tag': 'v0.2.5'
+                 'tag': 'v0.2.5',
+                 'subject': 'tag message',
                  'sections': [{'commits': [{'author': 'John Doe',
                                             'body': '',
                                             'subject': 'Updating Changelog installation.'}],

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -949,6 +949,14 @@ class GitCommit(SubGitObjectMixin):
         d = datetime.datetime.utcfromtimestamp(
             float(self.tagger_date_timestamp))
         return d.strftime('%Y-%m-%d')
+    
+    @property
+    def tag_subject(self):
+        if not self.has_annotated_tag:
+            raise ValueError("Can't access 'tag_subject' on commit without annotated tag.")        
+        tag_subject = self.git.for_each_ref(
+            'refs/tags/%s' % self.identifier, format='%(contents:subject)')
+        return tag_subject
 
     def __le__(self, value):
         if not isinstance(value, GitCommit):
@@ -1579,6 +1587,7 @@ def versions_data_iter(repository, revlist=None,
             "tagger_date": tag.tagger_date if tag.has_annotated_tag else None,
             "tag": tag.identifier if tag.identifier != "HEAD" else None,
             "commit": tag,
+            "subject": tag.tag_subject if tag.has_annotated_tag else None,
         }
 
         sections = collections.defaultdict(list)

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -953,7 +953,7 @@ class GitCommit(SubGitObjectMixin):
     @property
     def tag_subject(self):
         if not self.has_annotated_tag:
-            raise ValueError("Can't access 'tag_subject' on commit without annotated tag.")        
+            raise ValueError("Can't access 'tag_subject' on commit without annotated tag.")
         tag_subject = self.git.for_each_ref(
             'refs/tags/%s' % self.identifier, format='%(contents:subject)')
         return tag_subject

--- a/test/test_tag_data.py
+++ b/test/test_tag_data.py
@@ -13,12 +13,11 @@ import textwrap
 from .common import BaseGitReposTest
 
 
-
 def simple_renderer(data, opts):
     s = ""
     for version in data["versions"]:
-        s += "%s: %s (%s)\n" % (version["tag"], 
-                            version["subject"], 
+        s += "%s: %s (%s)\n" % (version["tag"],
+                            version["subject"],
                             version["tagger_date"])
         for section in version["sections"]:
             s += "  %s:\n" % section["label"]
@@ -26,6 +25,7 @@ def simple_renderer(data, opts):
                 s += "    * %(subject)s [%(author)s]\n" % commit
         s += "\n"
     return s
+
 
 class TagSubjectTest(BaseGitReposTest):
 

--- a/test/test_tag_data.py
+++ b/test/test_tag_data.py
@@ -1,0 +1,50 @@
+# -*- encoding: utf-8 -*-
+"""Testing tag data
+
+Currently only testing tag subject but to be extended when more tag data is 
+included
+
+"""
+
+from __future__ import unicode_literals
+
+import textwrap
+
+from .common import BaseGitReposTest
+
+
+
+def simple_renderer(data, opts):
+    s = ""
+    for version in data["versions"]:
+        s += "%s: %s (%s)\n" % (version["tag"], 
+                            version["subject"], 
+                            version["tagger_date"])
+        for section in version["sections"]:
+            s += "  %s:\n" % section["label"]
+            for commit in section["commits"]:
+                s += "    * %(subject)s [%(author)s]\n" % commit
+        s += "\n"
+    return s
+
+class TagSubjectTest(BaseGitReposTest):
+
+    REFERENCE = textwrap.dedent("""\
+        1.2: tag message (2017-03-17)
+          None:
+            * b [The Committer]
+
+        """)
+
+    def setUp(self):
+        super(TagSubjectTest, self).setUp()
+
+        self.git.commit(message="b",
+                        date="2017-02-20 11:00:00",
+                        allow_empty=True)
+        self.git.tag(['-a', "1.2", '--message=tag message'],
+                     env={'GIT_COMMITTER_DATE': "2017-03-17 11:00:00"})
+
+    def test_checking_tag_subject(self):
+        out = self.changelog(output_engine=simple_renderer)
+        self.assertNoDiff(self.REFERENCE, out)


### PR DESCRIPTION
Make tag's subject available in the version data structure to be used in the changelog (fixes #77 - at least partly)