### PR TITLE
new: added 'path' config option to limit commit messages 

### DIFF
--- a/src/gitchangelog/gitchangelog.rc.reference
+++ b/src/gitchangelog/gitchangelog.rc.reference
@@ -287,3 +287,13 @@ include_merge = True
 #    "HEAD"
 #]
 revs = []
+
+
+## ``path`` is a string
+##
+## This option tells ``gitchangelog`` which path within the repository 
+## ``git log`` should be called from.
+##
+## If not defined or None, the default, ``gitchangelog`` will look at commits 
+## for all directories within the repo.
+#path = r''

--- a/test/test_config_file.py
+++ b/test/test_config_file.py
@@ -140,6 +140,25 @@ class BasicCallOnSimpleGit(BaseGitReposTest):
         self.assertEqual(errlvl, 1)
         self.assertContains(err.lower(), "syntax error")
 
+    def test_no_path_restrictions(self):
+        gitchangelog.file_put_contents(
+            ".gitchangelog.rc",
+            "path = r''")
+
+        changelog = w('$tprog')
+        self.assertContains(changelog, "Bob",
+            msg="Should include 'Bob'..."
+            "content of changelog:\n%s" % changelog)
+
+    def test_path_restrictions(self):
+        gitchangelog.file_put_contents(
+            ".gitchangelog.rc",
+            "path = r'does/not/exist'")
+
+        changelog = w('$tprog')
+        self.assertNotContains(changelog, "Bob",
+            msg="Should be empty with path restriction..."
+            "content of changelog:\n%s" % changelog)
 
 class TestOnUnreleased(BaseGitReposTest):
 

--- a/test/test_git_repos.py
+++ b/test/test_git_repos.py
@@ -53,6 +53,14 @@ class GitReposTest(BaseGitReposTest):
             commit.subject,
             'add ``b`` with non-ascii chars éèàâ§µ and HTML chars ``&<``')
 
+    def test_log_nonexistent_path(self):
+        logs = list(self.repos.log(path=r'/does/not/exist'))
+        self.assertEqual(logs, [], 'Expected no logs with non-existent path restriction')
+
+    def test_log_default_path(self):
+        logs = list(self.repos.log(path=r''))
+        self.assertTrue(len(logs) > 0, 'Expected logs with default path restriction; got none')
+
     def test_exception_when_requesting_unexistent_commit(self):
         commit = self.repos.commit("XXX")  ## No exception yet.
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This introduces a new optional 'path' config file parameter which allows end-users to run 'git log ... [path]' instead of 'git log ...'.  The net effect here is this makes it easy to limit commits to those that affected a certain set directory and its contents only.  Hopefully this capability didn't already exist in some other capacity:)