### PR TITLE
Change section headers to be less prominent

### DIFF
--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -7,7 +7,7 @@
 ## {{{label}}}
 
 {{#sections}}
-### {{{label}}}
+**{{{label}}}**
 
 {{#commits}}
 * {{{subject}}} [{{{author}}}]


### PR DESCRIPTION
I have changed the section headers from an h3 to just bold, as I think there is too much visual clutter in the Markdown template, as most elements are headers. This way looks a bit better rendered.