### PR TITLE
Reference to commit

### DIFF
--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1512,7 +1512,8 @@ def versions_data_iter(repository, revlist=None,
                        body_process=lambda x: x,
                        subject_process=lambda x: x,
                        log_encoding=DEFAULT_GIT_LOG_ENCODING,
-                       warn=warn,        ## Mostly used for test
+                       warn=warn,        ## Mostly used for test,
+                       **kwargs
                        ):
     """Returns an iterator through versions data structures
 
@@ -1528,6 +1529,7 @@ def versions_data_iter(repository, revlist=None,
     :param subject_process: text processing object to apply to subject
     :param log_encoding: the encoding used in git logs
     :param warn: callable to output warnings, mocked by tests
+    :param project_commit_url: Url for setting commit ref
 
     :returns: iterator of versions data_structures
 
@@ -1656,6 +1658,7 @@ def changelog(output_engine=rest_py,
     else:
         data["versions"] = itertools.chain([first_version], versions)
 
+    data["project_commit_url"] = kwargs.get("project_commit_url", "")
     return output_engine(data=data, opts=opts)
 
 ##
@@ -1964,6 +1967,7 @@ def main():
             body_process=config.get("body_process", noop),
             subject_process=config.get("subject_process", noop),
             log_encoding=log_encoding,
+            project_commit_url=config.get("project_commit_url", "")
         )
 
         if isinstance(content, basestring):

--- a/src/gitchangelog/gitchangelog.rc.reference
+++ b/src/gitchangelog/gitchangelog.rc.reference
@@ -287,3 +287,9 @@ include_merge = True
 #    "HEAD"
 #]
 revs = []
+
+
+# variable to reference on template commit link for example
+# https://github.com/<user>/<project_name>/commits/
+# script will join this url with the commit sha1
+project_commit_url = ""

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -10,7 +10,7 @@
 ### {{{label}}}
 
 {{#commits}}
-* {{{subject}}} [{{{author}}}]
+* {{{subject}}} [{{{author}}}] [{{commit.sha1}}]({{project_commit_url}}{{commit.sha1}})
 {{#body}}
 
 {{{body_indented}}}

--- a/src/gitchangelog/templates/mustache/restructuredtext.tpl
+++ b/src/gitchangelog/templates/mustache/restructuredtext.tpl
@@ -2,7 +2,6 @@
 {{{title}}}
 {{#title_chars}}={{/title_chars}}
 
-
 {{/general_title}}
 {{#versions}}
 {{{label}}}
@@ -14,7 +13,7 @@
 {{#label_chars}}~{{/label_chars}}
 {{/display_label}}
 {{#commits}}
-- {{{subject}}} [{{{author_names_joined}}}]
+- {{{subject}}} [{{{author_names_joined}}}] `[{{commit.sha1}}] <{{project_commit_url}}{{commit.sha1}}>`_
 
 {{#body}}
 {{{body_indented}}}

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -88,6 +88,26 @@ class GitChangelogTest(BaseGitReposTest):
           """
     )
 
+    MUSTACHE_INCR_REFERENCE_002_003 = textwrap.dedent(
+        """\
+        0.0.3 (2000-01-05)
+        ------------------
+
+        New
+        ~~~
+        - Add file ``e``, modified ``b`` [Bob] `[{bob_commit}] <{bob_commit}>`_
+
+          This is a message body.
+
+          With multi-line content:
+          - one
+          - two
+        - Add file ``c`` [Charly] `[{charly_commit}] <{charly_commit}>`_
+
+
+        """
+    )
+
     INCR_REFERENCE_002_003 = textwrap.dedent(
         """\
         0.0.3 (2000-01-05)
@@ -414,7 +434,15 @@ class GitChangelogTest(BaseGitReposTest):
             ".gitchangelog.rc", "output_engine = mustache('restructuredtext')"
         )
         changelog = w("$tprog 0.0.2..0.0.3")
-        self.assertNoDiff(self.INCR_REFERENCE_002_003, changelog)
+
+        # get second commit from Bob
+        bob_commit = self.get_commits("Bob")[1]
+        # get first commit
+        charly_commit = self.get_commits("Charly")[0]
+        self.assertNoDiff(self.MUSTACHE_INCR_REFERENCE_002_003.format(**{
+            "charly_commit": charly_commit,
+            "bob_commit": bob_commit,
+        }), changelog)
 
         gitchangelog.file_put_contents(
             ".gitchangelog.rc",

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -2,18 +2,21 @@
 
 from __future__ import unicode_literals
 
-import os.path
 import glob
+import os.path
+import re
 import textwrap
 
-from .common import BaseGitReposTest, w, cmd, gitchangelog
 from gitchangelog.gitchangelog import indent
+
+from .common import BaseGitReposTest, w, cmd, gitchangelog
 
 
 class GitChangelogTest(BaseGitReposTest):
     """Base for all tests needing to start in a new git small repository"""
 
-    REFERENCE = textwrap.dedent("""\
+    REFERENCE = textwrap.dedent(
+        """\
           Changelog
           =========
 
@@ -46,9 +49,47 @@ class GitChangelogTest(BaseGitReposTest):
           - Add ``b`` with non-ascii chars éèàâ§µ and HTML chars ``&<`` [Alice]
 
 
-          """)
+          """
+    )
 
-    INCR_REFERENCE_002_003 = textwrap.dedent("""\
+    MUSTACHE_REFERENCE = textwrap.dedent(
+        """\
+          Changelog
+          =========
+
+          (unreleased)
+          ------------
+
+          Changes
+          ~~~~~~~
+          - Modified ``b`` XXX. [Alice, Charly, Juliet] `[{co_authores_commits}] <{co_authores_commits}>`_
+
+
+          0.0.3 (2000-01-05)
+          ------------------
+
+          New
+          ~~~
+          - Add file ``e``, modified ``b`` [Bob] `[{bob_commit}] <{bob_commit}>`_
+
+            This is a message body.
+
+            With multi-line content:
+            - one
+            - two
+          - Add file ``c`` [Charly] `[{charly_commit}] <{charly_commit}>`_
+
+
+          0.0.2 (2000-01-02)
+          ------------------
+          - Add ``b`` with non-ascii chars éèàâ§µ and HTML chars ``&<`` [Alice] `[{alice_commit}] <{alice_commit}>`_
+
+
+          """
+    )
+
+    INCR_REFERENCE_002_003 = textwrap.dedent(
+        """\
         0.0.3 (2000-01-05)
         ------------------
 
@@ -64,33 +105,45 @@ class GitChangelogTest(BaseGitReposTest):
         - Add file ``c`` [Charly]
 
 
-        """)
+        """
+    )
+
+    def get_commits(self, username):
+        return re.findall(
+            r"commit\s(.*)\nAuthor: {}".format(username), self.git.log()
+        )
 
     def setUp(self):
         super(GitChangelogTest, self).setUp()
 
-        self.git.commit(
-            message='new: first commit',
-            author='Bob <bob@example.com>',
-            date='2000-01-01 10:00:00',
-            allow_empty=True)
+        self.bob_commit_1 = self.git.commit(
+            message="new: first commit",
+            author="Bob <bob@example.com>",
+            date="2000-01-01 10:00:00",
+            allow_empty=True,
+        )
         self.git.tag("0.0.1")
-        self.git.commit(
-            message=textwrap.dedent("""
+        self.alice_commit_2 = self.git.commit(
+            message=textwrap.dedent(
+                """
                 add ``b`` with non-ascii chars éèàâ§µ and HTML chars ``&<``
 
-                Change-Id: Ic8aaa0728a43936cd4c6e1ed590e01ba8f0fbf5b"""),
-            author='Alice <alice@example.com>',
-            date='2000-01-02 11:00:00',
-            allow_empty=True)
+                Change-Id: Ic8aaa0728a43936cd4c6e1ed590e01ba8f0fbf5b"""
+            ),
+            author="Alice <alice@example.com>",
+            date="2000-01-02 11:00:00",
+            allow_empty=True,
+        )
         self.git.tag("0.0.2")
-        self.git.commit(
-            message='new: add file ``c``',
-            author='Charly <charly@example.com>',
-            date='2000-01-03 12:00:00',
-            allow_empty=True)
-        self.git.commit(
-            message=textwrap.dedent("""
+        self.charly_commit_3 = self.git.commit(
+            message="new: add file ``c``",
+            author="Charly <charly@example.com>",
+            date="2000-01-03 12:00:00",
+            allow_empty=True,
+        )
+        self.bob_commit_4 = self.git.commit(
+            message=textwrap.dedent(
+                """
                 new: add file ``e``, modified ``b``
 
                 This is a message body.
@@ -105,90 +158,121 @@ class GitChangelogTest(BaseGitReposTest):
                 CC: R. E. Viewer <reviewer@example.com>
                 Subject: This is a fake subject spanning to several lines
                   as you can see
-                """),
-            author='Bob <bob@example.com>',
-            date='2000-01-04 13:00:00',
-            allow_empty=True)
-        self.git.commit(
-            message='chg: modified ``b`` !minor',
-            author='Bob <bob@example.com>',
-            date='2000-01-05 13:00:00',
-            allow_empty=True)
+                """
+            ),
+            author="Bob <bob@example.com>",
+            date="2000-01-04 13:00:00",
+            allow_empty=True,
+        )
+        self.bob_commit_5 = self.git.commit(
+            message="chg: modified ``b`` !minor",
+            author="Bob <bob@example.com>",
+            date="2000-01-05 13:00:00",
+            allow_empty=True,
+        )
         self.git.tag("0.0.3")
-        self.git.commit(
-            message=textwrap.dedent("""
+        self.alice_commit_6 = self.git.commit(
+            message=textwrap.dedent(
+                """
                 chg: modified ``b`` XXX
 
                 Co-Authored-By: Juliet <juliet@example.com>
                 Co-Authored-By: Charly <charly@example.com>
-                """),
-            author='Alice <alice@example.com>',
-            date='2000-01-06 11:00:00',
-            allow_empty=True)
+                """
+            ),
+            author="Alice <alice@example.com>",
+            date="2000-01-06 11:00:00",
+            allow_empty=True,
+        )
 
     def test_simple_run_no_args_legacy_call(self):
-        out, err, errlvl = cmd('$tprog')
+        out, err, errlvl = cmd("$tprog")
         self.assertEqual(
-            err, "",
+            err,
+            "",
             msg="There should be no standard error outputed. "
-            "Current stderr:\n%r" % err)
+                "Current stderr:\n%r" % err,
+        )
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
         self.assertContains(
-            out, "0.0.2",
+            out,
+            "0.0.2",
             msg="At least one of the tags should be displayed in stdout... "
-            "Current stdout:\n%s" % out)
+                "Current stdout:\n%s" % out,
+        )
         self.assertNoDiff(self.REFERENCE, out)
 
     def test_simple_run_show_call_deprecated(self):
-        out, err, errlvl = cmd('$tprog show')
+        out, err, errlvl = cmd("$tprog show")
         self.assertContains(
-            err, "deprecated",
+            err,
+            "deprecated",
             msg="There should be a warning about deprecated calls. "
-            "Current stderr:\n%r" % err)
+                "Current stderr:\n%r" % err,
+        )
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
         self.assertContains(
-            out, "0.0.2",
+            out,
+            "0.0.2",
             msg="At least one of the tags should be displayed in stdout... "
-            "Current stdout:\n%s" % out)
+                "Current stdout:\n%s" % out,
+        )
         self.assertNoDiff(self.REFERENCE, out)
 
     def test_incremental_call(self):
-        out, err, errlvl = cmd('$tprog 0.0.2..0.0.3')
+        out, err, errlvl = cmd("$tprog 0.0.2..0.0.3")
         self.assertEqual(
-            err, "",
+            err,
+            "",
             msg="There should be no standard error outputed. "
-            "Current stderr:\n%r" % err)
+                "Current stderr:\n%r" % err,
+        )
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
         self.assertContains(
-            out, "0.0.3",
+            out,
+            "0.0.3",
             msg="The tag 0.0.3 should be displayed in stdout... "
-            "Current stdout:\n%s" % out)
+                "Current stdout:\n%s" % out,
+        )
         self.assertNoDiff(self.INCR_REFERENCE_002_003, out)
 
     def test_incremental_call_multirev(self):
         out, err, errlvl = cmd('$tprog "^0.0.2" 0.0.3 0.0.3')
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
         self.assertEqual(
-            err, "",
+            err,
+            "",
             msg="There should be no standard error outputed. "
-            "Current stderr:\n%r" % err)
+                "Current stderr:\n%r" % err,
+        )
         self.assertContains(
-            out, "0.0.3",
+            out,
+            "0.0.3",
             msg="The tag 0.0.3 should be displayed in stdout... "
-            "Current stdout:\n%s" % out)
+                "Current stdout:\n%s" % out,
+        )
         self.assertNoDiff(self.INCR_REFERENCE_002_003, out)
 
     def test_incremental_call_one_commit_unreleased(self):
         out, err, errlvl = cmd('$tprog "^HEAD^" HEAD')
-        REFERENCE = textwrap.dedent("""\
+        REFERENCE = textwrap.dedent(
+            """\
             (unreleased)
             ------------
 
@@ -197,20 +281,25 @@ class GitChangelogTest(BaseGitReposTest):
             - Modified ``b`` XXX. [Alice, Charly, Juliet]
 
 
-            """)
+            """
+        )
         self.assertEqual(
-            err, "",
+            err,
+            "",
             msg="There should be no standard error outputed. "
-            "Current stderr:\n%s" % err)
+                "Current stderr:\n%s" % err,
+        )
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
-        self.assertNoDiff(
-            REFERENCE, out)
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
+        self.assertNoDiff(REFERENCE, out)
 
     def test_incremental_call_one_commit_released(self):
         out, err, errlvl = cmd('$tprog "0.0.3^^^..0.0.3^^"')
-        REFERENCE = textwrap.dedent("""\
+        REFERENCE = textwrap.dedent(
+            """\
             0.0.3 (2000-01-05)
             ------------------
 
@@ -219,33 +308,46 @@ class GitChangelogTest(BaseGitReposTest):
             - Add file ``c`` [Charly]
 
 
-            """)
+            """
+        )
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
         self.assertEqual(
-            err, "",
+            err,
+            "",
             msg="There should be no standard error outputed. "
-            "Current stderr:\n%r" % err)
+                "Current stderr:\n%r" % err,
+        )
         self.assertContains(
-            out, "0.0.3",
+            out,
+            "0.0.3",
             msg="The tag 0.0.3 should be displayed in stdout... "
-            "Current stdout:\n%s" % out)
+                "Current stdout:\n%s" % out,
+        )
         self.assertNoDiff(REFERENCE, out)
 
     def test_incremental_show_call_deprecated(self):
-        out, err, errlvl = cmd('$tprog show 0.0.2..0.0.3')
+        out, err, errlvl = cmd("$tprog show 0.0.2..0.0.3")
         self.assertEqual(
-            errlvl, 0,
-            msg="Should not fail on simple repo and without config file")
+            errlvl,
+            0,
+            msg="Should not fail on simple repo and without config file",
+        )
         self.assertContains(
-            err, "deprecated",
+            err,
+            "deprecated",
             msg="There should be a deprecated warning. "
-            "Current stderr:\n%r" % err)
+                "Current stderr:\n%r" % err,
+        )
         self.assertContains(
-            out, "0.0.3",
+            out,
+            "0.0.3",
             msg="The tag 0.0.3 should be displayed in stdout... "
-            "Current stdout:\n%s" % out)
+                "Current stdout:\n%s" % out,
+        )
         self.assertNoDiff(self.INCR_REFERENCE_002_003, out)
 
     def test_provided_config_file(self):
@@ -253,13 +355,18 @@ class GitChangelogTest(BaseGitReposTest):
 
         config_dir = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
-            "..", "src", "gitchangelog")
-        configs = glob.glob(os.path.join(config_dir,
-                                         "gitchangelog.rc.reference.v*"))
+            "..",
+            "src",
+            "gitchangelog",
+        )
+        configs = glob.glob(
+            os.path.join(config_dir, "gitchangelog.rc.reference.v*")
+        )
         self.assertNotEqual(len(configs), 0)
         for config in configs:
             out, err, errlvl = cmd(
-                '$tprog', env={'GITCHANGELOG_CONFIG_FILENAME': config})
+                "$tprog", env={"GITCHANGELOG_CONFIG_FILENAME": config}
+            )
             self.assertEqual(errlvl, 0)
             self.assertNoDiff(self.REFERENCE, out)
 
@@ -267,48 +374,80 @@ class GitChangelogTest(BaseGitReposTest):
         """Reference implem should match mustache and mako implem"""
 
         gitchangelog.file_put_contents(
-            ".gitchangelog.rc",
-            "output_engine = mustache('restructuredtext')")
-        changelog = w('$tprog')
+            ".gitchangelog.rc", "output_engine = mustache('restructuredtext')"
+        )
+        changelog = w("$tprog")
+
+        # get first commit from Alice
+        alice_commits = self.get_commits("Alice")
+        alice_commit = alice_commits[1]
+        # get second commit from Bob
+        bob_commit = self.get_commits("Bob")[1]
+        # get first commit
+        charly_commit = self.get_commits("Charly")[0]
+        # get first commit from Alice where has co-authores
+        co_authores_commits = alice_commits[0]
+
         self.assertNoDiff(
-            self.REFERENCE, changelog)
+            self.MUSTACHE_REFERENCE.format(
+                **{
+                    "alice_commit": alice_commit,
+                    "charly_commit": charly_commit,
+                    "bob_commit": bob_commit,
+                    "co_authores_commits": co_authores_commits
+                }
+            ),
+            changelog,
+        )
 
         gitchangelog.file_put_contents(
             ".gitchangelog.rc",
-            "output_engine = makotemplate('restructuredtext')")
-        changelog = w('$tprog')
+            "output_engine = makotemplate('restructuredtext')",
+        )
+        changelog = w("$tprog")
         self.assertNoDiff(self.REFERENCE, changelog)
 
     def test_same_output_with_different_engine_incr(self):
         """Reference implem should match mustache and mako implem (incr)"""
 
-        gitchangelog.file_put_contents(".gitchangelog.rc",
-                          "output_engine = mustache('restructuredtext')")
-        changelog = w('$tprog 0.0.2..0.0.3')
+        gitchangelog.file_put_contents(
+            ".gitchangelog.rc", "output_engine = mustache('restructuredtext')"
+        )
+        changelog = w("$tprog 0.0.2..0.0.3")
         self.assertNoDiff(self.INCR_REFERENCE_002_003, changelog)
 
-        gitchangelog.file_put_contents(".gitchangelog.rc",
-                          "output_engine = makotemplate('restructuredtext')")
-        changelog = w('$tprog 0.0.2..0.0.3')
+        gitchangelog.file_put_contents(
+            ".gitchangelog.rc",
+            "output_engine = makotemplate('restructuredtext')",
+        )
+        changelog = w("$tprog 0.0.2..0.0.3")
         self.assertNoDiff(self.INCR_REFERENCE_002_003, changelog)
 
     def test_provided_templates(self):
         """Run all provided templates at least once"""
 
-        for label, directory in [("makotemplate", "mako"),
-                                 ("mustache", "mustache")]:
+        for label, directory in [
+            ("makotemplate", "mako"),
+            ("mustache", "mustache"),
+        ]:
             template_dir = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
-                "..", "templates", directory)
+                "..",
+                "templates",
+                directory,
+            )
             templates = glob.glob(os.path.join(template_dir, "*.tpl"))
-            template_labels = [os.path.basename(f).split(".")[0]
-                               for f in templates]
+            template_labels = [
+                os.path.basename(f).split(".")[0] for f in templates
+            ]
             for tpl in template_labels:
-                gitchangelog.file_put_contents(".gitchangelog.rc",
-                                  "output_engine = %s(%r)" % (label, tpl))
-                out, err, errlvl = cmd('$tprog')
+                gitchangelog.file_put_contents(
+                    ".gitchangelog.rc", "output_engine = %s(%r)" % (label, tpl)
+                )
+                out, err, errlvl = cmd("$tprog")
                 self.assertEqual(
-                    errlvl, 0,
-                    msg="Should not fail on %s(%r) " % (label, tpl) +
-                    "Current stderr:\n%s" % indent(err))
-
+                    errlvl,
+                    0,
+                    msg="Should not fail on %s(%r) " % (label, tpl)
+                        + "Current stderr:\n%s" % indent(err),
+                )


### PR DESCRIPTION
Hello!

I'm starting to use changelogs in my apps and I saw some libraries in js that make similar functionality to this, but I don´t want to use JS in a Python project and that's why I'm here.

I like the tool very much because let me use any version format. And in my work, I use a strange format, but **I need new functionality** that makes me **reference to commit**, that's why I´m PR this project to make possible this feature getting this from the configuration. I commented in the rc file how it's works, but it's quite simple, it only need to set `project_commit_url` with the URL to the commits project.

Gitlab: `https://gitlab.com/<user>/<project>/-/commit/<commit.sha1>`
Github: `https://github.com/<user>/<project>/commit/<commit.sha1>`
Bitbucket: `https://bitbucket.org/<user>/<project>/commits/<commit.sha1>`

I wasn't sure if we care about user and project in the tool, so that's why I used direct link instead of `user` and `project` because we should control each platform and it could be complex to maintain if it will change in the future.

I hope you liked :) regards